### PR TITLE
fix failed to CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,6 @@ go:
     - 1.4.x
 before_install:
     - go get github.com/tools/godep
-    - go get github.com/davecgh/go-spew/spew
-    - go get github.com/k0kubun/pp
-    - go get github.com/mattn/goveralls
-    - go get golang.org/x/tools/cmd/cover
-    - go get github.com/modocache/gover
     - godep restore
     - sudo apt-get update -qq
     - sudo apt-get install -y openssl libcppunit-dev libreadline6 libreadline6-dev valgrind realpath libmodule-install-perl

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,9 @@ setup: installpkgs metalinter
 installpkgs::
 	@$(CMD_ECHO)  -e "\033[1;40;32mInstall Packages.\033[01;m\x1b[0m"
 	@$(CMD_GO) get github.com/Masterminds/glide
+ifeq ($(GOLANGV18_OVER),1)
 	@$(CMD_GO) get github.com/Songmu/make2help/cmd/make2help
+endif
 	@$(CMD_GO) get github.com/davecgh/go-spew/spew
 	@$(CMD_GO) get github.com/k0kubun/pp
 	@$(CMD_GO) get github.com/mattn/goveralls
@@ -81,7 +83,6 @@ ifeq ($(GOLANGV19_OVER),1)
 	@$(CMD_GO) get github.com/alecthomas/gometalinter
 endif
 ifeq ($(GOLANGV110_OVER),1)
-	@$(CMD_ECHO) -e "What???"
 	@$(CMD_GO) get github.com/awalterschulze/gographviz
 	@$(CMD_GO) get github.com/golangci/golangci-lint/cmd/golangci-lint
 endif

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,7 @@ PATH_PROF_BLOCK=$(PKG_NAME).block.prof
 PATH_PROF_MUTEX=$(PKG_NAME).mutex.prof
 
 VER_GOLANG=$(shell go version | awk '{print $$3}' | sed -e "s/go//;s/\.//g")
+GOLANGV110_OVER=$(shell [ "$(VER_GOLANG)" -gt "199" ] && echo 1 || echo 0)
 GOLANGV19_OVER=$(shell [ "$(VER_GOLANG)" -ge "190" ] && echo 1 || echo 0)
 GOLANGV18_OVER=$(shell [ "$(VER_GOLANG)" -ge "180" ] && echo 1 || echo 0)
 GOLANGV16_OVER=$(shell [ "$(VER_GOLANG)" -ge "169" ] && echo 1 || echo 0)
@@ -79,7 +80,11 @@ ifeq ($(GOLANGV19_OVER),1)
 	@$(CMD_GO) get github.com/golang/lint/golint
 	@$(CMD_GO) get github.com/alecthomas/gometalinter
 endif
-	@$(CMD_GO) get -u github.com/awalterschulze/gographviz
+ifeq ($(GOLANGV110_OVER),1)
+	@$(CMD_ECHO) -e "What???"
+	@$(CMD_GO) get github.com/awalterschulze/gographviz
+	@$(CMD_GO) get github.com/golangci/golangci-lint/cmd/golangci-lint
+endif
 	@$(CMD_ECHO) -e "\033[1;40;36mDone\033[01;m\x1b[0m"
 
 ## Build the go-mdbm
@@ -94,6 +99,16 @@ metalinter::
 	@$(CMD_ECHO)  -e "\033[1;40;32mInstall Go-metalineter.\033[01;m\x1b[0m"
 ifeq ($(GOLANGV19_OVER),1)
 	@$(shell which gometalinter) --install
+else
+	@$(CMD_ECHO) -e "\033[1;40;36mSKIP: your golang is older version $(shell go version)\033[01;m\x1b[0m"
+endif
+	@$(CMD_ECHO) -e "\033[1;40;36mDone\033[01;m\x1b[0m"
+
+## Install Golangci-lint
+metalinter::
+	@$(CMD_ECHO)  -e "\033[1;40;32mInstall Golangci-Lint.\033[01;m\x1b[0m"
+ifeq ($(GOLANGV110_OVER),1)
+	@$(shell which golangci-lint) run
 else
 	@$(CMD_ECHO) -e "\033[1;40;36mSKIP: your golang is older version $(shell go version)\033[01;m\x1b[0m"
 endif

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,6 @@ ifeq ($(GOLANGV18_OVER),1)
 	@$(CMD_GO) get github.com/Songmu/make2help/cmd/make2help
 endif
 	@$(CMD_GO) get github.com/davecgh/go-spew/spew
-	@$(CMD_GO) get github.com/k0kubun/pp
 	@$(CMD_GO) get github.com/mattn/goveralls
 	@$(CMD_GO) get golang.org/x/tools/cmd/cover
 	@$(CMD_GO) get github.com/modocache/gover
@@ -79,6 +78,7 @@ endif
 	@$(CMD_GO) get github.com/pkg/errors
 	@$(CMD_GO) get github.com/torden/go-strutil
 ifeq ($(GOLANGV17_OVER),1)
+	@$(CMD_GO) get github.com/k0kubun/pp
 	@$(CMD_GO) get golang.org/x/sys/unix
 endif
 ifeq ($(GOLANGV19_OVER),1)

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ VER_GOLANG=$(shell go version | awk '{print $$3}' | sed -e "s/go//;s/\.//g")
 GOLANGV110_OVER=$(shell [ "$(VER_GOLANG)" -gt "199" ] && echo 1 || echo 0)
 GOLANGV19_OVER=$(shell [ "$(VER_GOLANG)" -ge "190" ] && echo 1 || echo 0)
 GOLANGV18_OVER=$(shell [ "$(VER_GOLANG)" -ge "180" ] && echo 1 || echo 0)
+GOLANGV17_OVER=$(shell [ "$(VER_GOLANG)" -ge "170" ] && echo 1 || echo 0)
 GOLANGV16_OVER=$(shell [ "$(VER_GOLANG)" -ge "169" ] && echo 1 || echo 0)
 
 CFLAGS="-I/usr/local/mdbm/include/ -I./"
@@ -77,7 +78,9 @@ endif
 	@$(CMD_GO) get github.com/boltdb/bolt
 	@$(CMD_GO) get github.com/pkg/errors
 	@$(CMD_GO) get github.com/torden/go-strutil
+ifeq ($(GOLANGV17_OVER),1)
 	@$(CMD_GO) get golang.org/x/sys/unix
+endif
 ifeq ($(GOLANGV19_OVER),1)
 	@$(CMD_GO) get github.com/golang/lint/golint
 	@$(CMD_GO) get github.com/alecthomas/gometalinter


### PR DESCRIPTION
- Make2help not support go1.8under
- Now, gograviz not support go 1.10 under version

> #make installpkgs
> Install Packages.
> github.com/awalterschulze/gographviz/internal/errors
> ../../awalterschulze/gographviz/internal/errors/errors.go:24:11: undefined: strings.Builder
> ../../awalterschulze/gographviz/internal/errors/errors.go:45:11: undefined: strings.Builder
> Makefile:67: recipe for target 'installpkgs' failed
> make: *** [installpkgs] Error 2

